### PR TITLE
Skip null audit fields in insert

### DIFF
--- a/pengdows.crud/EntityHelper.cs
+++ b/pengdows.crud/EntityHelper.cs
@@ -201,13 +201,23 @@ public class EntityHelper<TEntity, TRowID> :
         {
             if (column.IsId && !column.IsIdIsWritable) continue;
 
+            var value = column.MakeParameterValueFromField(objectToCreate);
+
+            // If no audit resolver is provided and the value is null for an audit column,
+            // skip including this column so database defaults will apply.
+            if (_auditValueResolver == null &&
+                (column.IsCreatedBy || column.IsCreatedOn || column.IsLastUpdatedBy || column.IsLastUpdatedOn) &&
+                Utils.IsNullOrDbNull(value))
+            {
+                continue;
+            }
+
             if (columns.Length > 0)
             {
                 columns.Append(", ");
                 values.Append(", ");
             }
 
-            var value = column.MakeParameterValueFromField(objectToCreate);
             var p = _context.CreateDbParameter(
                 column.DbType,
                 value


### PR DESCRIPTION
## Summary
- allow DB defaults for audit columns when no audit resolver

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684482cc4e448325add035cc71ef9d1f